### PR TITLE
fix: add context menu commands for GitGPT extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "git-ai-helper",
-  "version": "0.0.1",
+  "name": "git-gpt",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "git-ai-helper",
-      "version": "0.0.1",
+      "name": "git-gpt",
+      "version": "0.0.3",
       "dependencies": {
         "axios": "^1.7.8",
         "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -17,20 +17,25 @@
     "menus": {
       "editor/title": [
         {
-          "command": "webview-api.openWebView",
+          "command": "gitgpt.openAIAssistant",
           "group": "navigation"
         }
       ]
     },
     "commands": [
       {
-        "command": "webview-api.openWebView",
-        "title": "Open Webview",
-        "icon": "$(browser)"
+        "command": "gitgpt.openAIAssistant",
+        "title": "GitGPT: Open AI Assistant",
+        "icon": "$(comment-discussion)"
       },
       {
-        "command": "llm-interaction.queryLLM",
-        "title": "Query LLM"
+        "command": "gitgpt.openGitLogViewer",
+        "title": "GitGPT: Open Git Log Viewer",
+        "icon": "$(git-branch)"
+      },
+      {
+        "command": "gitgpt.queryLLM",
+        "title": "GitGPT: Query AI Assistant"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ const terminalName = "WebView Terminal";
 
 export function activate(context: vscode.ExtensionContext) {
     let queryLLM = vscode.commands.registerCommand(
-        'llm-interaction.queryLLM',
+        'gitgpt.queryLLM',
         async () => {
             const cwd = vscode.workspace.workspaceFolders?.[0].uri.fsPath ?? (() => { throw new Error('No workspace folder is open.'); })();
 
@@ -23,8 +23,8 @@ export function activate(context: vscode.ExtensionContext) {
         }
     );
 
-    let openWebView = vscode.commands.registerCommand(
-        "webview-api.openWebView",
+    let openAIAssistant = vscode.commands.registerCommand(
+        "gitgpt.openAIAssistant",
         () => {
             try {
                 const webviewPanel = WebviewPanel.getInstance(context);
@@ -47,7 +47,33 @@ export function activate(context: vscode.ExtensionContext) {
         }
     );
 
-    context.subscriptions.push(queryLLM, openWebView);
+    let openGitLogViewer = vscode.commands.registerCommand(
+        "gitgpt.openGitLogViewer",
+        () => {
+            try {
+                /**
+                 * webviewpanel應設置為可以打開兩個不同的webview
+                 */
+                const webviewPanel = WebviewPanel.getInstance(context);
+                const cwd = vscode.workspace.workspaceFolders?.[0].uri.fsPath ?? (() => { throw new Error('No workspace folder is open.'); })();
+
+                webviewPanel.onDidReceiveMessage((message) => {
+                    /**
+                     * 當git相關指令被執行時，調用git log取得log並在log tree page中顯示
+                     */
+                });
+            } catch (error) {
+                if (error instanceof Error) {
+                    vscode.window.showErrorMessage(`Error: ${error.message}`);
+                } else {
+                    vscode.window.showErrorMessage(`Unknown error occurred.`);
+                }
+                console.log(error);
+            }
+        }
+    );
+
+    context.subscriptions.push(queryLLM, openAIAssistant, openGitLogViewer);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
1. 統一命令命名方式，將原本的 `llm-interaction.queryLLM` 命令重新命名為 `gitgpt.queryLLM`。
2. gitgpt.queryLLM 表示與 AI 對話的功能。
3. gitgpt.openGitLogViewer 表示視覺化 Git log 的功能。
4. 為命令新增適當的 VS Code 原生圖標（Codicon），提升用戶體驗。