### PR TITLE
Fix/select workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
       {
         "command": "gitgpt.queryLLM",
         "title": "GitGPT: Query AI Assistant"
+      },
+      {
+        "command": "gitgpt.selectWorkspace",
+        "title": "GitGPT: Select Workspace"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ class WorkspaceManager {
     // 選擇 Workspace 資料夾
     private async selectWorkspaceFolder(): Promise<string | undefined> {
         const folderUri = await vscode.window.showOpenDialog({
+            defaultUri: vscode.workspace.workspaceFolders?.[0]?.uri,
             canSelectFiles: false,
             canSelectFolders: true,
             canSelectMany: false,


### PR DESCRIPTION
1. 新增功能：Workspace 切換
- 使用者可以通過命令 gitgpt.selectWorkspace 選擇工作空間（資料夾）。
- 在使用相關功能（如 Git 操作）時，自動檢查當前工作空間，避免出錯。

2. 優化功能：Status Bar 顯示
- Status Bar 現在動態顯示當前選擇的 Workspace 資料夾名稱。
- 當滑鼠懸停時，工具提示會顯示完整路徑，方便使用者查看詳細資訊。
- 點擊 Status Bar 可直接切換 Workspace，提升交互體驗。

包括一個較新的commit，實現代碼重構: 將與 Workspace 和 Status Bar 相關的邏輯封裝為 WorkspaceManager 類。